### PR TITLE
Add KML extension methods and related unit tests

### DIFF
--- a/src/GISLibrary.Tests/GeoExtensionsTests.cs
+++ b/src/GISLibrary.Tests/GeoExtensionsTests.cs
@@ -2,6 +2,7 @@
 using Tudormobile.GeoJSON;
 using Tudormobile.GIS;
 using Tudormobile.Gpx;
+using Tudormobile.Kml;
 using Tudormobile.Tcx;
 
 namespace GISLibrary.Tests;
@@ -12,7 +13,47 @@ namespace GISLibrary.Tests;
 [TestClass]
 public class GeoExtensionsTests
 {
-    #region AsGeoPath Tests - GeoJSONPolygon
+    [TestMethod]
+    public void AsGeoPath_KmlPlacemark_WithLineString_ReturnsGeoPath()
+    {
+        // Arrange
+        var lineString = new KmlLineString([(10, 20, 100), (15, 25, 150)]);
+        var placemark = new KmlPlacemark(new KmlPlacemarkItem("", "", "", lineString));
+        // Act
+        var result = placemark.AsGeoPath();
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(2, result.Count);
+        Assert.AreEqual(new GeoPosition(10.0, 20.0, 100.0), result[0]);
+        Assert.AreEqual(new GeoPosition(15.0, 25.0, 150.0), result[1]);
+    }
+
+    [TestMethod]
+    public void AsGeoPath_KmlPlacemark_WithPolygon_ReturnsGeoPath()
+    {
+        // Arrange
+        var polygon = new KmlPolygon([(30, 40, 200), (35, 45, 250)], [[(30, 50, 300), (30, 40, 200)]]);
+        var placemark = new KmlPlacemark(new KmlPlacemarkItem("", "", "", polygon));
+        // Act
+        var result = placemark.AsGeoPath();
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(2, result.Count);
+        Assert.AreEqual(new GeoPosition(30.0, 40.0, 200.0), result[0]);
+        Assert.AreEqual(new GeoPosition(35.0, 45.0, 250.0), result[1]);
+    }
+
+    [TestMethod]
+    public void AsGeoPath_KmlPlacemark_WithPoint_ReturnsNull()
+    {
+        // Arrange
+        var point = new KmlPoint(50, 60, 300);
+        var placemark = new KmlPlacemark(new KmlPlacemarkItem("", "", "", point));
+        // Act
+        var result = placemark.AsGeoPath();
+        // Assert
+        Assert.IsNull(result);
+    }
 
     /// <summary>
     /// Tests that AsGeoPath converts a GeoJSON polygon with a single ring to a GeoPath.
@@ -158,10 +199,6 @@ public class GeoExtensionsTests
         Assert.AreEqual(new GeoPosition(3.0, 4.0, 0), result[1]);
     }
 
-    #endregion
-
-    #region AsGeoPath Tests - TcxActivity
-
     /// <summary>
     /// Tests that AsGeoPath converts a TCX activity with trackpoints to a GeoPath.
     /// </summary>
@@ -270,10 +307,6 @@ public class GeoExtensionsTests
         Assert.AreEqual(new GeoPosition(38.0, -122.6, 20.0), result[1]);
     }
 
-    #endregion
-
-    #region AsGeoPath Tests - TCX Trackpoints
-
     /// <summary>
     /// Tests that AsGeoPath converts TCX trackpoints to a GeoPath.
     /// </summary>
@@ -342,9 +375,6 @@ public class GeoExtensionsTests
         Assert.IsNotNull(result);
         Assert.AreEqual(0, result.Count);
     }
-
-    #endregion
-
 
     /// <summary>
     /// Tests that AsGeoPath converts GPX waypoints to a GeoPath.

--- a/src/GISLibrary.Tests/Kml/KmlExtensionsTests.cs
+++ b/src/GISLibrary.Tests/Kml/KmlExtensionsTests.cs
@@ -217,8 +217,4 @@ public class KmlExtensionsTests
     }
 
 
-
-
-
 }
-

--- a/src/GISLibrary.Tests/Kml/KmlExtensionsTests.cs
+++ b/src/GISLibrary.Tests/Kml/KmlExtensionsTests.cs
@@ -1,0 +1,224 @@
+﻿using Tudormobile.Kml;
+
+namespace GISLibrary.Tests.Kml;
+
+[TestClass]
+public class KmlExtensionsTests
+{
+    [TestMethod]
+    public void AllPointPlacemarks_WithNoPoints_ReturnsEmptyEnumerable()
+    {
+        // Arrange
+        var kmlDoc = new KmlDocument(new KmlDocumentItem("", "", ""));
+        kmlDoc.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "LineString Placemark", new KmlLineString([]))));
+        kmlDoc.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "Polygon Placemark", new KmlPolygon([], [[]]))));
+        // Act
+        var pointPlacemarks = kmlDoc.AllPointPlacemarks();
+        // Assert
+        Assert.IsNotNull(pointPlacemarks);
+        Assert.IsEmpty(pointPlacemarks);
+    }
+
+    [TestMethod]
+    public void AllLineStringPlacemarks_ReturnsLineStrings()
+    {
+        // Arrange
+        var kmlDoc = new KmlDocument(new KmlDocumentItem("", "", ""));
+        kmlDoc.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "LineString Placemark", new KmlLineString([]))));
+        kmlDoc.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "Polygon Placemark", new KmlPolygon([], [[]]))));
+        // Act
+        var lineStringPlacemarks = kmlDoc.AllLineStringPlacemarks();
+        // Assert
+        Assert.IsNotNull(lineStringPlacemarks);
+        Assert.HasCount(1, lineStringPlacemarks);
+    }
+
+    [TestMethod]
+    public void AllPolygonPlacemarks_ReturnsPolygons()
+    {
+        // Arrange
+        var kmlDoc = new KmlDocument(new KmlDocumentItem("", "", ""));
+        kmlDoc.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "LineString Placemark", new KmlLineString([]))));
+        kmlDoc.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "Polygon Placemark", new KmlPolygon([], [[]]))));
+        // Act
+        var polygonPlacemarks = kmlDoc.AllPolygonPlacemarks();
+        // Assert
+        Assert.IsNotNull(polygonPlacemarks);
+        Assert.HasCount(1, polygonPlacemarks);
+    }
+
+    [TestMethod]
+    public void KmlFolder_AllPointPlacemarks_WithNoPoints_ReturnsEmptyEnumerable()
+    {
+        // Arrange
+        var kmlFolder = new KmlFolder(new KmlFolderItem("", "", ""));
+        kmlFolder.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "LineString Placemark", new KmlLineString([]))));
+        kmlFolder.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "Polygon Placemark", new KmlPolygon([], [[]]))));
+        // Act
+        var pointPlacemarks = kmlFolder.AllPointPlacemarks();
+        // Assert
+        Assert.IsNotNull(pointPlacemarks);
+        Assert.IsEmpty(pointPlacemarks);
+    }
+
+    [TestMethod]
+    public void KmlFolder_AllLineStringPlacemarks_ReturnsLineStrings()
+    {
+        // Arrange
+        var kmlFolder = new KmlFolder(new KmlFolderItem("", "", ""));
+        kmlFolder.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "LineString Placemark", new KmlLineString([]))));
+        kmlFolder.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "Polygon Placemark", new KmlPolygon([], [[]]))));
+        // Act
+        var lineStringPlacemarks = kmlFolder.AllLineStringPlacemarks();
+        // Assert
+        Assert.IsNotNull(lineStringPlacemarks);
+        Assert.HasCount(1, lineStringPlacemarks);
+    }
+
+    [TestMethod]
+    public void KmlFolder_AllPolygonPlacemarks_ReturnsPolygons()
+    {
+        // Arrange
+        var kmlFolder = new KmlFolder(new KmlFolderItem("", "", ""));
+        kmlFolder.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "LineString Placemark", new KmlLineString([]))));
+        kmlFolder.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "Polygon Placemark", new KmlPolygon([], [[]]))));
+        // Act
+        var polygonPlacemarks = kmlFolder.AllPolygonPlacemarks();
+        // Assert
+        Assert.IsNotNull(polygonPlacemarks);
+        Assert.HasCount(1, polygonPlacemarks);
+    }
+
+    [TestMethod]
+    public void AllPointPlacemarks_WithPoints_ReturnsPlacemarks()
+    {
+        // Arrange
+        var kmlDoc = new KmlDocument(new KmlDocumentItem("", "", ""));
+        kmlDoc.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "Point Placemark", new KmlPoint(0, 0, 0))));
+        kmlDoc.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "Point Placemark", new KmlPoint(0, 0, 0))));
+        kmlDoc.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "LineString Placemark", new KmlLineString([]))));
+        kmlDoc.Placemarks.Add(new KmlPlacemark(new KmlPlacemarkItem("", "", "Polygon Placemark", new KmlPolygon([], [[]]))));
+        // Act
+        var pointPlacemarks = kmlDoc.AllPointPlacemarks();
+        // Assert
+        Assert.IsNotNull(pointPlacemarks);
+        Assert.HasCount(2, pointPlacemarks);
+    }
+
+    [TestMethod]
+    public void ToLineString_WithLineStringGeometry_ReturnsLineString()
+    {
+        // Arrange
+        var lineString = new KmlLineString([(0, 0, 0), (1, 1, 0)]);
+        var placemark = new KmlPlacemark(new KmlPlacemarkItem("", "", "LineString Placemark", lineString));
+        // Act
+        var result = placemark.ToLineString();
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(lineString, result);
+    }
+
+    [TestMethod]
+    public void ToPoint_WithPointGeometry_ReturnsPoint()
+    {
+        // Arrange
+        var point = new KmlPoint(0, 0, 0);
+        var placemark = new KmlPlacemark(new KmlPlacemarkItem("", "", "Point Placemark", point));
+        // Act
+        var result = placemark.ToPoint();
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(point, result);
+    }
+
+    [TestMethod]
+    public void ToPolygon_WithPolygonGeometry_ReturnsPolygon()
+    {
+        // Arrange
+        var polygon = new KmlPolygon([], [[]]);
+        var placemark = new KmlPlacemark(new KmlPlacemarkItem("", "", "Polygon Placemark", polygon));
+        // Act
+        var result = placemark.ToPolygon();
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(polygon, result);
+    }
+
+    [TestMethod]
+    public void AsLineString_WithLineStringGeometry_ReturnsLineString()
+    {
+        // Arrange
+        var lineString = new KmlLineString([(0, 0, 0), (1, 1, 0)]);
+        var placemark = new KmlPlacemark(new KmlPlacemarkItem("", "", "LineString Placemark", lineString));
+        // Act
+        var result = placemark.AsLineString();
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(lineString, result);
+    }
+
+    [TestMethod]
+    public void AsPolygon_WithPolygonGeometry_ReturnsPolygon()
+    {
+        // Arrange
+        var polygon = new KmlPolygon([], [[]]);
+        var placemark = new KmlPlacemark(new KmlPlacemarkItem("", "", "Polygon Placemark", polygon));
+        // Act
+        var result = placemark.AsPolygon();
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(polygon, result);
+    }
+
+    [TestMethod]
+    public void AsPoint_WithPointGeometry_ReturnsPoint()
+    {
+        // Arrange
+        var point = new KmlPoint(0, 0, 0);
+        var placemark = new KmlPlacemark(new KmlPlacemarkItem("", "", "Point Placemark", point));
+        // Act
+        var result = placemark.AsPoint();
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(point, result);
+    }
+
+    [TestMethod]
+    public void AsLineString_WithoutLineStringGeometry_ReturnsNull()
+    {
+        // Arrange
+        var placemark = new KmlPlacemark(new KmlPlacemarkItem("", "", "", new KmlUnsupportedGeometry()));
+        // Act
+        var result = placemark.AsLineString();
+        // Assert
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void AsPolygon_WithoutPolygonGeometry_ReturnsNull()
+    {
+        // Arrange
+        var placemark = new KmlPlacemark(new KmlPlacemarkItem("", "", "", new KmlUnsupportedGeometry()));
+        // Act
+        var result = placemark.AsPolygon();
+        // Assert
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void AsPoint_WithoutPointGeometry_ReturnsNull()
+    {
+        // Arrange
+        var placemark = new KmlPlacemark(new KmlPlacemarkItem("", "", "", new KmlUnsupportedGeometry()));
+        // Act
+        var result = placemark.AsPoint();
+        // Assert
+        Assert.IsNull(result);
+    }
+
+
+
+
+
+}
+

--- a/src/GISLibrary/GeoExtensions.cs
+++ b/src/GISLibrary/GeoExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Tudormobile.GeoJSON;
 using Tudormobile.Gpx;
+using Tudormobile.Kml;
 using Tudormobile.Tcx;
 
 namespace Tudormobile.GIS;
@@ -9,6 +10,21 @@ namespace Tudormobile.GIS;
 /// </summary>
 public static class GeoExtensions
 {
+    /// <summary>
+    /// Converts a KML placemark to a GeoPath by extracting coordinates from its geometry.
+    /// </summary>
+    /// <param name="placemark">The KML placemark to convert. Cannot be null.</param>
+    /// <returns>
+    /// A GeoPath containing the coordinates from the placemark's geometry, or null if the geometry is not a line or polygon.
+    /// </returns>
+    public static GeoPath? AsGeoPath(this KmlPlacemark placemark)
+    => placemark.Geometry switch
+    {
+        KmlLineString lineString => new GeoPath().AddRange(lineString.Coordinates.Select(coord => new GeoPosition(coord.Latitude, coord.Longitude, coord.Altitude))),
+        KmlPolygon polygon => new GeoPath().AddRange(polygon.OuterBoundary.Select(coord => new GeoPosition(coord.Latitude, coord.Longitude, coord.Altitude))),
+        _ => null
+    };
+
     /// <summary>
     /// Converts the first ring of the specified GeoJSON polygon to a GeoPath instance.
     /// </summary>

--- a/src/GISLibrary/Kml/KmlExtensions.cs
+++ b/src/GISLibrary/Kml/KmlExtensions.cs
@@ -1,0 +1,112 @@
+﻿namespace Tudormobile.Kml;
+
+/// <summary>
+/// Provides extension methods for KML documents, folders, and placemarks to simplify filtering and geometry conversion.
+/// </summary>
+public static class KmlExtensions
+{
+    /// <summary>
+    /// Gets all placemarks in the KML document that have Point geometry.
+    /// </summary>
+    /// <param name="doc">The KML document to search.</param>
+    /// <returns>An enumerable collection of placemarks with Point geometry.</returns>
+    public static IEnumerable<KmlPlacemark> AllPointPlacemarks(this KmlDocument doc)
+        => doc.AllPlacemarks.Where(x => x.Geometry.GeometryType == KmlGeometryType.Point);
+
+    /// <summary>
+    /// Gets all placemarks in the KML document that have LineString geometry.
+    /// </summary>
+    /// <param name="doc">The KML document to search.</param>
+    /// <returns>An enumerable collection of placemarks with LineString geometry.</returns>
+    public static IEnumerable<KmlPlacemark> AllLineStringPlacemarks(this KmlDocument doc)
+        => doc.AllPlacemarks.Where(x => x.Geometry.GeometryType == KmlGeometryType.LineString);
+
+    /// <summary>
+    /// Gets all placemarks in the KML document that have Polygon geometry.
+    /// </summary>
+    /// <param name="doc">The KML document to search.</param>
+    /// <returns>An enumerable collection of placemarks with Polygon geometry.</returns>
+    public static IEnumerable<KmlPlacemark> AllPolygonPlacemarks(this KmlDocument doc)
+        => doc.AllPlacemarks.Where(x => x.Geometry.GeometryType == KmlGeometryType.Polygon);
+
+    /// <summary>
+    /// Gets all placemarks in the KML folder that have Point geometry.
+    /// </summary>
+    /// <param name="folder">The KML folder to search.</param>
+    /// <returns>An enumerable collection of placemarks with Point geometry.</returns>
+    public static IEnumerable<KmlPlacemark> AllPointPlacemarks(this KmlFolder folder)
+        => folder.Placemarks.Where(x => x.Geometry.GeometryType == KmlGeometryType.Point);
+
+    /// <summary>
+    /// Gets all placemarks in the KML folder that have LineString geometry.
+    /// </summary>
+    /// <param name="folder">The KML folder to search.</param>
+    /// <returns>An enumerable collection of placemarks with LineString geometry.</returns>
+    public static IEnumerable<KmlPlacemark> AllLineStringPlacemarks(this KmlFolder folder)
+        => folder.Placemarks.Where(x => x.Geometry.GeometryType == KmlGeometryType.LineString);
+
+    /// <summary>
+    /// Gets all placemarks in the KML folder that have Polygon geometry.
+    /// </summary>
+    /// <param name="folder">The KML folder to search.</param>
+    /// <returns>An enumerable collection of placemarks with Polygon geometry.</returns>
+    public static IEnumerable<KmlPlacemark> AllPolygonPlacemarks(this KmlFolder folder)
+        => folder.Placemarks.Where(x => x.Geometry.GeometryType == KmlGeometryType.Polygon);
+
+    /// <summary>
+    /// Converts the placemark's geometry to a <see cref="KmlLineString"/>.
+    /// </summary>
+    /// <param name="placemark">The placemark whose geometry to convert.</param>
+    /// <returns>A <see cref="KmlLineString"/> instance.</returns>
+    /// <exception cref="InvalidCastException">Thrown when the placemark's geometry is not a LineString.</exception>
+    public static KmlLineString ToLineString(this KmlPlacemark placemark)
+        => (KmlLineString)placemark.Geometry;
+
+    /// <summary>
+    /// Attempts to convert the placemark's geometry to a <see cref="KmlLineString"/>.
+    /// </summary>
+    /// <param name="placemark">The placemark whose geometry to convert.</param>
+    /// <returns>A <see cref="KmlLineString"/> instance if the geometry is a LineString; otherwise, null.</returns>
+    public static KmlLineString? AsLineString(this KmlPlacemark placemark)
+        => placemark.Geometry.GeometryType == KmlGeometryType.LineString
+        ? (KmlLineString)placemark.Geometry
+        : null;
+
+    /// <summary>
+    /// Converts the placemark's geometry to a <see cref="KmlPolygon"/>.
+    /// </summary>
+    /// <param name="placemark">The placemark whose geometry to convert.</param>
+    /// <returns>A <see cref="KmlPolygon"/> instance.</returns>
+    /// <exception cref="InvalidCastException">Thrown when the placemark's geometry is not a Polygon.</exception>
+    public static KmlPolygon ToPolygon(this KmlPlacemark placemark)
+    => (KmlPolygon)placemark.Geometry;
+
+    /// <summary>
+    /// Attempts to convert the placemark's geometry to a <see cref="KmlPolygon"/>.
+    /// </summary>
+    /// <param name="placemark">The placemark whose geometry to convert.</param>
+    /// <returns>A <see cref="KmlPolygon"/> instance if the geometry is a Polygon; otherwise, null.</returns>
+    public static KmlPolygon? AsPolygon(this KmlPlacemark placemark)
+        => placemark.Geometry.GeometryType == KmlGeometryType.Polygon
+        ? (KmlPolygon)placemark.Geometry
+        : null;
+
+    /// <summary>
+    /// Converts the placemark's geometry to a <see cref="KmlPoint"/>.
+    /// </summary>
+    /// <param name="placemark">The placemark whose geometry to convert.</param>
+    /// <returns>A <see cref="KmlPoint"/> instance.</returns>
+    /// <exception cref="InvalidCastException">Thrown when the placemark's geometry is not a Point.</exception>
+    public static KmlPoint ToPoint(this KmlPlacemark placemark)
+    => (KmlPoint)placemark.Geometry;
+
+    /// <summary>
+    /// Attempts to convert the placemark's geometry to a <see cref="KmlPoint"/>.
+    /// </summary>
+    /// <param name="placemark">The placemark whose geometry to convert.</param>
+    /// <returns>A <see cref="KmlPoint"/> instance if the geometry is a Point; otherwise, null.</returns>
+    public static KmlPoint? AsPoint(this KmlPlacemark placemark)
+        => placemark.Geometry.GeometryType == KmlGeometryType.Point
+        ? (KmlPoint)placemark.Geometry
+        : null;
+}


### PR DESCRIPTION
Introduce KmlExtensions for filtering and casting placemarks by geometry type (Point, LineString, Polygon) for KmlDocument and KmlFolder. Add AsGeoPath for KmlPlacemark in GeoExtensions. Provide comprehensive unit tests for new KML extensions and AsGeoPath. Clean up redundant comments in GeoExtensionsTests.